### PR TITLE
walkingkooka-tree/pull/204 20201102

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/function/string/CharExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/string/CharExpressionFunction.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.tree.expression.function.string;
 
+import walkingkooka.Cast;
 import walkingkooka.tree.expression.FunctionExpressionName;
 import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
@@ -26,12 +27,19 @@ import java.util.List;
  * Converts the only parameter to a character.
  * <a href="https://support.google.com/docs/answer/3094120?hl=en&ref_topic=3105625">CHAR</a>
  */
-final class CharExpressionFunction extends StringExpressionFunction<Character> {
+final class CharExpressionFunction<C extends ExpressionFunctionContext> extends StringExpressionFunction<Character, C> {
+
+    /**
+     * Instance getter.
+     */
+    static <C extends ExpressionFunctionContext> CharExpressionFunction<C> instance() {
+        return Cast.to(INSTANCE);
+    }
 
     /**
      * Singleton
      */
-    static final CharExpressionFunction INSTANCE = new CharExpressionFunction();
+    private static final CharExpressionFunction INSTANCE = new CharExpressionFunction();
 
     /**
      * Private ctor
@@ -42,7 +50,7 @@ final class CharExpressionFunction extends StringExpressionFunction<Character> {
 
     @Override
     public Character apply(final List<Object> parameters,
-                           final ExpressionFunctionContext context) {
+                           final C context) {
         this.checkParameterCount(parameters, 1);
 
         final int value = this.integer(parameters, 0, context);

--- a/src/main/java/walkingkooka/tree/expression/function/string/ConcatExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/string/ConcatExpressionFunction.java
@@ -34,6 +34,7 @@
 
 package walkingkooka.tree.expression.function.string;
 
+import walkingkooka.Cast;
 import walkingkooka.tree.expression.FunctionExpressionName;
 import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
@@ -43,12 +44,19 @@ import java.util.stream.Collectors;
 /**
  * A function that concats all the Strings given to it.
  */
-final class ConcatExpressionFunction extends StringExpressionFunction<String> {
+final class ConcatExpressionFunction<C extends ExpressionFunctionContext> extends StringExpressionFunction<String, C> {
+
+    /**
+     * Instance getter.
+     */
+    static <C extends ExpressionFunctionContext> ConcatExpressionFunction<C> instance() {
+        return Cast.to(INSTANCE);
+    }
 
     /**
      * Singleton
      */
-    static final ConcatExpressionFunction INSTANCE = new ConcatExpressionFunction();
+    private static final ConcatExpressionFunction INSTANCE = new ConcatExpressionFunction();
 
     /**
      * Private ctor
@@ -59,7 +67,7 @@ final class ConcatExpressionFunction extends StringExpressionFunction<String> {
 
     @Override
     public String apply(final List<Object> parameters,
-                        final ExpressionFunctionContext context) {
+                        final C context) {
         final int count = parameters.size();
         if (count < 1) {
             throw new IllegalArgumentException("Expected at least 1 parameter but got " + count + "=" + parameters.subList(1, count));

--- a/src/main/java/walkingkooka/tree/expression/function/string/ContainsExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/string/ContainsExpressionFunction.java
@@ -34,18 +34,26 @@
 
 package walkingkooka.tree.expression.function.string;
 
+import walkingkooka.Cast;
 import walkingkooka.tree.expression.FunctionExpressionName;
 import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
 /**
  * A function that returns true if the second string is contained within the first string.
  */
-final class ContainsExpressionFunction extends StringStringBooleanExpressionFunction {
+final class ContainsExpressionFunction<C extends ExpressionFunctionContext> extends StringStringBooleanExpressionFunction<C> {
+
+    /**
+     * Instance getter.
+     */
+    static <C extends ExpressionFunctionContext> ContainsExpressionFunction<C> instance() {
+        return Cast.to(INSTANCE);
+    }
 
     /**
      * Singleton
      */
-    static final ContainsExpressionFunction INSTANCE = new ContainsExpressionFunction();
+    private static final ContainsExpressionFunction INSTANCE = new ContainsExpressionFunction();
 
     /**
      * Private ctor

--- a/src/main/java/walkingkooka/tree/expression/function/string/EndsWithExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/string/EndsWithExpressionFunction.java
@@ -34,18 +34,26 @@
 
 package walkingkooka.tree.expression.function.string;
 
+import walkingkooka.Cast;
 import walkingkooka.tree.expression.FunctionExpressionName;
 import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
 /**
  * A function that returns true if the first string ends with the second string.
  */
-final class EndsWithExpressionFunction extends StringStringBooleanExpressionFunction {
+final class EndsWithExpressionFunction<C extends ExpressionFunctionContext> extends StringStringBooleanExpressionFunction<C> {
+
+    /**
+     * Instance getter.
+     */
+    static <C extends ExpressionFunctionContext> EndsWithExpressionFunction<C> instance() {
+        return Cast.to(INSTANCE);
+    }
 
     /**
      * Singleton
      */
-    static final EndsWithExpressionFunction INSTANCE = new EndsWithExpressionFunction();
+    private static final EndsWithExpressionFunction INSTANCE = new EndsWithExpressionFunction();
 
     /**
      * Private ctor

--- a/src/main/java/walkingkooka/tree/expression/function/string/LeftStringExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/string/LeftStringExpressionFunction.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.tree.expression.function.string;
 
+import walkingkooka.Cast;
 import walkingkooka.tree.expression.FunctionExpressionName;
 import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
@@ -24,12 +25,19 @@ import walkingkooka.tree.expression.function.ExpressionFunctionContext;
  * Performs a left for a given {@link String}. Defaults to 1 if the number or second parameter is absent and uses 0 if the 2nd parameter is negative.
  * <a href="https://support.google.com/docs/answer/3094079?hl=en">LEFT</a>
  */
-final class LeftStringExpressionFunction extends StringOptionalNumberStringExpressionFunction {
+final class LeftStringExpressionFunction<C extends ExpressionFunctionContext> extends StringOptionalNumberStringExpressionFunction<C> {
+
+    /**
+     * Instance getter.
+     */
+    static <C extends ExpressionFunctionContext> LeftStringExpressionFunction<C> instance() {
+        return Cast.to(INSTANCE);
+    }
 
     /**
      * Singleton
      */
-    static final LeftStringExpressionFunction INSTANCE = new LeftStringExpressionFunction();
+    private static final LeftStringExpressionFunction INSTANCE = new LeftStringExpressionFunction();
 
     /**
      * Private ctor

--- a/src/main/java/walkingkooka/tree/expression/function/string/LowerCaseStringExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/string/LowerCaseStringExpressionFunction.java
@@ -16,17 +16,25 @@
  */
 package walkingkooka.tree.expression.function.string;
 
+import walkingkooka.Cast;
 import walkingkooka.tree.expression.FunctionExpressionName;
 import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
 /**
  * Performs a lower case converting the value to a {@link String} using the current {@link java.util.Locale}.
  */
-final class LowerCaseStringExpressionFunction extends UnaryStringExpressionFunction<String> {
+final class LowerCaseStringExpressionFunction<C extends ExpressionFunctionContext> extends UnaryStringExpressionFunction<String, C> {
+    /**
+     * Instance getter.
+     */
+    static <C extends ExpressionFunctionContext> LowerCaseStringExpressionFunction<C> instance() {
+        return Cast.to(INSTANCE);
+    }
+
     /**
      * Singleton
      */
-    static final LowerCaseStringExpressionFunction INSTANCE = new LowerCaseStringExpressionFunction();
+    private static final LowerCaseStringExpressionFunction INSTANCE = new LowerCaseStringExpressionFunction();
 
     /**
      * Private ctor

--- a/src/main/java/walkingkooka/tree/expression/function/string/MidStringExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/string/MidStringExpressionFunction.java
@@ -34,6 +34,7 @@
 
 package walkingkooka.tree.expression.function.string;
 
+import walkingkooka.Cast;
 import walkingkooka.tree.expression.FunctionExpressionName;
 import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
@@ -43,12 +44,19 @@ import java.util.List;
  * The excel mid function.
  * <a href="https://support.google.com/docs/answer/3094129?hl=en&ref_topic=3105625>MID</a>
  */
-final class MidStringExpressionFunction extends StringExpressionFunction<String> {
+final class MidStringExpressionFunction<C extends ExpressionFunctionContext> extends StringExpressionFunction<String, C> {
+
+    /**
+     * Instance getter.
+     */
+    static <C extends ExpressionFunctionContext> MidStringExpressionFunction<C> instance() {
+        return Cast.to(INSTANCE);
+    }
 
     /**
      * Singleton
      */
-    static final MidStringExpressionFunction INSTANCE = new MidStringExpressionFunction();
+    private static final MidStringExpressionFunction INSTANCE = new MidStringExpressionFunction();
 
     /**
      * Private ctor
@@ -59,7 +67,7 @@ final class MidStringExpressionFunction extends StringExpressionFunction<String>
 
     @Override
     public String apply(final List<Object> parameters,
-                        final ExpressionFunctionContext context) {
+                        final C context) {
         this.checkParameterCount(parameters, 3);
 
         final String string = this.string(parameters, 0, context);

--- a/src/main/java/walkingkooka/tree/expression/function/string/NormalizeSpaceExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/string/NormalizeSpaceExpressionFunction.java
@@ -34,6 +34,7 @@
 
 package walkingkooka.tree.expression.function.string;
 
+import walkingkooka.Cast;
 import walkingkooka.tree.expression.FunctionExpressionName;
 import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
@@ -46,11 +47,18 @@ import walkingkooka.tree.expression.function.ExpressionFunctionContext;
  * </pre>
  * Unlike the mention in the mozilla document, if the argument is missing, an exception will be thrown.
  */
-final class NormalizeSpaceExpressionFunction extends UnaryStringExpressionFunction<String> {
+final class NormalizeSpaceExpressionFunction<C extends ExpressionFunctionContext> extends UnaryStringExpressionFunction<String, C> {
+    /**
+     * Instance getter.
+     */
+    static <C extends ExpressionFunctionContext> NormalizeSpaceExpressionFunction<C> instance() {
+        return Cast.to(INSTANCE);
+    }
+
     /**
      * Singleton
      */
-    static final NormalizeSpaceExpressionFunction INSTANCE = new NormalizeSpaceExpressionFunction();
+    private static final NormalizeSpaceExpressionFunction INSTANCE = new NormalizeSpaceExpressionFunction();
 
     /**
      * Private ctor

--- a/src/main/java/walkingkooka/tree/expression/function/string/RightStringExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/string/RightStringExpressionFunction.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.tree.expression.function.string;
 
+import walkingkooka.Cast;
 import walkingkooka.tree.expression.FunctionExpressionName;
 import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
@@ -24,12 +25,19 @@ import walkingkooka.tree.expression.function.ExpressionFunctionContext;
  * Performs a right for a given {@link String}. Defaults to 1 if the number or second parameter is absent and uses 0 if the 2nd parameter is negative.
  * <a href="https://support.google.com/docs/answer/3094087?hl=en&ref_topic=3105625">RIGHT</a>
  */
-final class RightStringExpressionFunction extends StringOptionalNumberStringExpressionFunction {
+final class RightStringExpressionFunction<C extends ExpressionFunctionContext> extends StringOptionalNumberStringExpressionFunction<C> {
+
+    /**
+     * Instance getter.
+     */
+    static <C extends ExpressionFunctionContext> RightStringExpressionFunction<C> instance() {
+        return Cast.to(INSTANCE);
+    }
 
     /**
      * Singleton
      */
-    static final RightStringExpressionFunction INSTANCE = new RightStringExpressionFunction();
+    private static final RightStringExpressionFunction INSTANCE = new RightStringExpressionFunction();
 
     /**
      * Private ctor

--- a/src/main/java/walkingkooka/tree/expression/function/string/StartsWithExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/string/StartsWithExpressionFunction.java
@@ -34,18 +34,26 @@
 
 package walkingkooka.tree.expression.function.string;
 
+import walkingkooka.Cast;
 import walkingkooka.tree.expression.FunctionExpressionName;
 import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
 /**
  * A function that returns true if the first string starts with the second string.
  */
-final class StartsWithExpressionFunction extends StringStringBooleanExpressionFunction {
+final class StartsWithExpressionFunction<C extends ExpressionFunctionContext> extends StringStringBooleanExpressionFunction<C> {
+
+    /**
+     * Instance getter.
+     */
+    static <C extends ExpressionFunctionContext> StartsWithExpressionFunction<C> instance() {
+        return Cast.to(INSTANCE);
+    }
 
     /**
      * Singleton
      */
-    static final StartsWithExpressionFunction INSTANCE = new StartsWithExpressionFunction();
+    private static final StartsWithExpressionFunction INSTANCE = new StartsWithExpressionFunction();
 
     /**
      * Private ctor

--- a/src/main/java/walkingkooka/tree/expression/function/string/StringExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/string/StringExpressionFunction.java
@@ -43,7 +43,7 @@ import java.util.List;
 /**
  * Base class for many {@link ExpressionFunction} within this package.
  */
-abstract class StringExpressionFunction<T> implements ExpressionFunction<T> {
+abstract class StringExpressionFunction<T, C extends ExpressionFunctionContext> implements ExpressionFunction<T, C> {
 
     /**
      * Package private to limit sub classing.

--- a/src/main/java/walkingkooka/tree/expression/function/string/StringExpressionFunctions.java
+++ b/src/main/java/walkingkooka/tree/expression/function/string/StringExpressionFunctions.java
@@ -37,6 +37,7 @@ package walkingkooka.tree.expression.function.string;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.reflect.PublicStaticHelper;
 import walkingkooka.tree.expression.function.ExpressionFunction;
+import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
 import java.util.function.Consumer;
 
@@ -49,7 +50,7 @@ public final class StringExpressionFunctions implements PublicStaticHelper {
      * Visit all {@link ExpressionFunction functions}.
      */
     public static void visit(final int indexBias,
-                             final Consumer<ExpressionFunction<?>> consumer) {
+                             final Consumer<ExpressionFunction<?, ?>> consumer) {
         Lists.of(character(),
                 concat(),
                 contains(),
@@ -75,134 +76,134 @@ public final class StringExpressionFunctions implements PublicStaticHelper {
     /**
      * {@see CharExpressionFunction}
      */
-    public static ExpressionFunction<Character> character() {
-        return CharExpressionFunction.INSTANCE;
+    public static <C extends ExpressionFunctionContext> ExpressionFunction<Character, C> character() {
+        return CharExpressionFunction.instance();
     }
 
     /**
      * {@see ConcatExpressionFunction}
      */
-    public static ExpressionFunction<String> concat() {
-        return ConcatExpressionFunction.INSTANCE;
+    public static <C extends ExpressionFunctionContext> ExpressionFunction<String, C> concat() {
+        return ConcatExpressionFunction.instance();
     }
 
     /**
      * {@see ContainsExpressionFunction}
      */
-    public static ExpressionFunction<Boolean> contains() {
-        return ContainsExpressionFunction.INSTANCE;
+    public static <C extends ExpressionFunctionContext> ExpressionFunction<Boolean, C> contains() {
+        return ContainsExpressionFunction.instance();
     }
 
     /**
      * {@see EndsWithExpressionFunction}
      */
-    public static ExpressionFunction<Boolean> endsWith() {
-        return EndsWithExpressionFunction.INSTANCE;
+    public static <C extends ExpressionFunctionContext> ExpressionFunction<Boolean, C> endsWith() {
+        return EndsWithExpressionFunction.instance();
     }
 
     /**
      * {@see LeftStringExpressionFunction}
      */
-    public static ExpressionFunction<String> left() {
-        return LeftStringExpressionFunction.INSTANCE;
+    public static <C extends ExpressionFunctionContext> ExpressionFunction<String, C> left() {
+        return LeftStringExpressionFunction.instance();
     }
 
     /**
      * {@see LowerCaseStringExpressionFunction}
      */
-    public static ExpressionFunction<String> lowerCase() {
-        return LowerCaseStringExpressionFunction.INSTANCE;
+    public static <C extends ExpressionFunctionContext> ExpressionFunction<String, C> lowerCase() {
+        return LowerCaseStringExpressionFunction.instance();
     }
 
     /**
      * {@see MidStringExpressionFunction}
      */
-    public static ExpressionFunction<String> mid() {
-        return MidStringExpressionFunction.INSTANCE;
+    public static <C extends ExpressionFunctionContext> ExpressionFunction<String, C> mid() {
+        return MidStringExpressionFunction.instance();
     }
 
     /**
      * {@see NormalizeSpaceExpressionFunction}
      */
-    public static ExpressionFunction<String> normalizeSpace() {
-        return NormalizeSpaceExpressionFunction.INSTANCE;
+    public static <C extends ExpressionFunctionContext> ExpressionFunction<String, C> normalizeSpace() {
+        return NormalizeSpaceExpressionFunction.instance();
     }
 
     /**
      * {@see RightStringExpressionFunction}
      */
-    public static ExpressionFunction<String> right() {
-        return RightStringExpressionFunction.INSTANCE;
+    public static <C extends ExpressionFunctionContext> ExpressionFunction<String, C> right() {
+        return RightStringExpressionFunction.instance();
     }
 
     /**
      * {@see StartsWithExpressionFunction}
      */
-    public static ExpressionFunction<Boolean> startsWith() {
-        return StartsWithExpressionFunction.INSTANCE;
+    public static <C extends ExpressionFunctionContext> ExpressionFunction<Boolean, C> startsWith() {
+        return StartsWithExpressionFunction.instance();
     }
 
     /**
      * {@see StringLengthExpressionFunction}
      */
-    public static ExpressionFunction<Number> stringLength() {
-        return StringLengthExpressionFunction.INSTANCE;
+    public static <C extends ExpressionFunctionContext> ExpressionFunction<Number, C> stringLength() {
+        return StringLengthExpressionFunction.instance();
     }
 
     /**
      * {@see SubstringExpressionFunction}
      */
-    public static ExpressionFunction<String> substring(final int indexBias) {
+    public static <C extends ExpressionFunctionContext> ExpressionFunction<String, C> substring(final int indexBias) {
         return SubstringExpressionFunction.with(indexBias);
     }
 
     /**
      * {@see SubstringAfterExpressionFunction}
      */
-    public static ExpressionFunction<String> substringAfter() {
-        return SubstringAfterExpressionFunction.INSTANCE;
+    public static <C extends ExpressionFunctionContext> ExpressionFunction<String, C> substringAfter() {
+        return SubstringAfterExpressionFunction.instance();
     }
 
     /**
      * {@see SubstringBeforeExpressionFunction}
      */
-    public static ExpressionFunction<String> substringBefore() {
-        return SubstringBeforeExpressionFunction.INSTANCE;
+    public static <C extends ExpressionFunctionContext> ExpressionFunction<String, C> substringBefore() {
+        return SubstringBeforeExpressionFunction.instance();
     }
 
     /**
      * {@see TextExpressionFunction}
      */
-    public static ExpressionFunction<String> text() {
-        return TextExpressionFunction.INSTANCE;
+    public static <C extends ExpressionFunctionContext> ExpressionFunction<String, C> text() {
+        return TextExpressionFunction.instance();
     }
 
     /**
      * {@see TrimLeftStringExpressionFunction}
      */
-    public static ExpressionFunction<String> trimLeft() {
-        return TrimLeftStringExpressionFunction.INSTANCE;
+    public static <C extends ExpressionFunctionContext> ExpressionFunction<String, C> trimLeft() {
+        return TrimLeftStringExpressionFunction.instance();
     }
 
     /**
      * {@see TrimRightStringExpressionFunction}
      */
-    public static ExpressionFunction<String> trimRight() {
-        return TrimRightStringExpressionFunction.INSTANCE;
+    public static <C extends ExpressionFunctionContext> ExpressionFunction<String, C> trimRight() {
+        return TrimRightStringExpressionFunction.instance();
     }
 
     /**
      * {@see UnicodeExpressionFunction}
      */
-    public static ExpressionFunction<Number> unicode() {
-        return UnicodeExpressionFunction.INSTANCE;
+    public static <C extends ExpressionFunctionContext> ExpressionFunction<Number, C> unicode() {
+        return UnicodeExpressionFunction.instance();
     }
 
     /**
      * {@see UpperCaseStringExpressionFunction}
      */
-    public static ExpressionFunction<String> upperCase() {
-        return UpperCaseStringExpressionFunction.INSTANCE;
+    public static <C extends ExpressionFunctionContext> ExpressionFunction<String, C> upperCase() {
+        return UpperCaseStringExpressionFunction.instance();
     }
 
     /**

--- a/src/main/java/walkingkooka/tree/expression/function/string/StringLengthExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/string/StringLengthExpressionFunction.java
@@ -34,6 +34,7 @@
 
 package walkingkooka.tree.expression.function.string;
 
+import walkingkooka.Cast;
 import walkingkooka.tree.expression.FunctionExpressionName;
 import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
@@ -42,11 +43,18 @@ import walkingkooka.tree.expression.function.ExpressionFunctionContext;
  * <a href="https://developer.mozilla.org/en-US/docs/Web/XPath/Functions/string-length"></a>
  * Unlike the Mozilla documentation, if the argument is missing an exception is thrown.
  */
-final class StringLengthExpressionFunction extends UnaryStringExpressionFunction<Number> {
+final class StringLengthExpressionFunction<C extends ExpressionFunctionContext> extends UnaryStringExpressionFunction<Number, C> {
+    /**
+     * Instance getter.
+     */
+    static <C extends ExpressionFunctionContext> StringLengthExpressionFunction<C> instance() {
+        return Cast.to(INSTANCE);
+    }
+
     /**
      * Singleton
      */
-    static final StringLengthExpressionFunction INSTANCE = new StringLengthExpressionFunction();
+    private static final StringLengthExpressionFunction INSTANCE = new StringLengthExpressionFunction();
 
     /**
      * Private ctor

--- a/src/main/java/walkingkooka/tree/expression/function/string/StringOptionalNumberStringExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/string/StringOptionalNumberStringExpressionFunction.java
@@ -41,7 +41,7 @@ import java.util.List;
 /**
  * A function that requires a {@link String} and an optional {@link Number} returning a {@link String} result.
  */
-abstract class StringOptionalNumberStringExpressionFunction extends StringExpressionFunction<String> {
+abstract class StringOptionalNumberStringExpressionFunction<C extends ExpressionFunctionContext> extends StringExpressionFunction<String, C> {
 
     /**
      * Package private ctor
@@ -52,7 +52,7 @@ abstract class StringOptionalNumberStringExpressionFunction extends StringExpres
 
     @Override
     public final String apply(final List<Object> parameters,
-                              final ExpressionFunctionContext context) {
+                              final C context) {
         String result;
 
         final int count = parameters.size();

--- a/src/main/java/walkingkooka/tree/expression/function/string/StringStringBooleanExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/string/StringStringBooleanExpressionFunction.java
@@ -41,7 +41,7 @@ import java.util.List;
 /**
  * A function that requires 2 string parameters and returns a {@link Boolean} result.
  */
-abstract class StringStringBooleanExpressionFunction extends StringExpressionFunction<Boolean> {
+abstract class StringStringBooleanExpressionFunction<C extends ExpressionFunctionContext> extends StringExpressionFunction<Boolean, C> {
 
     /**
      * Package private ctor
@@ -52,7 +52,7 @@ abstract class StringStringBooleanExpressionFunction extends StringExpressionFun
 
     @Override
     public Boolean apply(final List<Object> parameters,
-                         final ExpressionFunctionContext context) {
+                         final C context) {
         this.checkParameterCount(parameters, 2);
 
         return this.applyStringString(this.string(parameters, 0, context),

--- a/src/main/java/walkingkooka/tree/expression/function/string/StringStringStringExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/string/StringStringStringExpressionFunction.java
@@ -41,7 +41,7 @@ import java.util.List;
 /**
  * A function that requires 2 string parameters and returns a {@link String} result.
  */
-abstract class StringStringStringExpressionFunction extends StringExpressionFunction<String> {
+abstract class StringStringStringExpressionFunction<C extends ExpressionFunctionContext> extends StringExpressionFunction<String, C> {
 
     /**
      * Package private ctor
@@ -52,7 +52,7 @@ abstract class StringStringStringExpressionFunction extends StringExpressionFunc
 
     @Override
     public String apply(final List<Object> parameters,
-                        final ExpressionFunctionContext context) {
+                        final C context) {
         this.checkParameterCount(parameters, 2);
 
         return this.applyStringString(this.string(parameters, 0, context),

--- a/src/main/java/walkingkooka/tree/expression/function/string/SubstringAfterExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/string/SubstringAfterExpressionFunction.java
@@ -34,18 +34,26 @@
 
 package walkingkooka.tree.expression.function.string;
 
+import walkingkooka.Cast;
 import walkingkooka.tree.expression.FunctionExpressionName;
 import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
 /**
  * A function that returns the part of string1 after the first occurrence of string2
  */
-final class SubstringAfterExpressionFunction extends StringStringStringExpressionFunction {
+final class SubstringAfterExpressionFunction<C extends ExpressionFunctionContext> extends StringStringStringExpressionFunction<C> {
+
+    /**
+     * Instance getter.
+     */
+    static <C extends ExpressionFunctionContext> SubstringAfterExpressionFunction<C> instance() {
+        return Cast.to(INSTANCE);
+    }
 
     /**
      * Singleton
      */
-    static final SubstringAfterExpressionFunction INSTANCE = new SubstringAfterExpressionFunction();
+    private static final SubstringAfterExpressionFunction INSTANCE = new SubstringAfterExpressionFunction();
 
     /**
      * Private ctor

--- a/src/main/java/walkingkooka/tree/expression/function/string/SubstringBeforeExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/string/SubstringBeforeExpressionFunction.java
@@ -34,18 +34,26 @@
 
 package walkingkooka.tree.expression.function.string;
 
+import walkingkooka.Cast;
 import walkingkooka.tree.expression.FunctionExpressionName;
 import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
 /**
  * A function that returns the part of string1 up before the first occurrence of string2
  */
-final class SubstringBeforeExpressionFunction extends StringStringStringExpressionFunction {
+final class SubstringBeforeExpressionFunction<C extends ExpressionFunctionContext> extends StringStringStringExpressionFunction<C> {
+
+    /**
+     * Instance getter.
+     */
+    static <C extends ExpressionFunctionContext> SubstringBeforeExpressionFunction<C> instance() {
+        return Cast.to(INSTANCE);
+    }
 
     /**
      * Singleton
      */
-    static final SubstringBeforeExpressionFunction INSTANCE = new SubstringBeforeExpressionFunction();
+    private static final SubstringBeforeExpressionFunction INSTANCE = new SubstringBeforeExpressionFunction();
 
     /**
      * Private ctor

--- a/src/main/java/walkingkooka/tree/expression/function/string/SubstringExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/string/SubstringExpressionFunction.java
@@ -43,13 +43,13 @@ import java.util.List;
  * A function that returns a substring of another string.<br>
  * <a href="https://developer.mozilla.org/en-US/docs/Web/XPath/Functions/substring"></a>
  */
-final class SubstringExpressionFunction extends StringExpressionFunction<String> {
+final class SubstringExpressionFunction<C extends ExpressionFunctionContext> extends StringExpressionFunction<String, C> {
 
     /**
      * Factory that returns a matching {@link SubstringExpressionFunction}
      */
-    static SubstringExpressionFunction with(final int indexBase) {
-        SubstringExpressionFunction result;
+    static <C extends ExpressionFunctionContext> SubstringExpressionFunction<C> with(final int indexBase) {
+        SubstringExpressionFunction<C> result;
         switch (indexBase) {
             case 0:
                 result = ZERO;
@@ -83,7 +83,7 @@ final class SubstringExpressionFunction extends StringExpressionFunction<String>
 
     @Override
     public String apply(final List<Object> parameters,
-                        final ExpressionFunctionContext context) {
+                        final C context) {
         final int parameterCount = parameters.size();
         switch (parameterCount) {
             case 2:

--- a/src/main/java/walkingkooka/tree/expression/function/string/TextExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/string/TextExpressionFunction.java
@@ -34,6 +34,7 @@
 
 package walkingkooka.tree.expression.function.string;
 
+import walkingkooka.Cast;
 import walkingkooka.tree.expression.FunctionExpressionName;
 import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
@@ -42,11 +43,18 @@ import java.util.List;
 /**
  * A function that converts the given value into a {@link String}.
  */
-final class TextExpressionFunction extends StringExpressionFunction<String> {
+final class TextExpressionFunction<C extends ExpressionFunctionContext> extends StringExpressionFunction<String, C> {
+    /**
+     * Instance getter.
+     */
+    static <C extends ExpressionFunctionContext> TextExpressionFunction<C> instance() {
+        return Cast.to(INSTANCE);
+    }
+
     /**
      * Singleton
      */
-    static final TextExpressionFunction INSTANCE = new TextExpressionFunction();
+    private static final TextExpressionFunction INSTANCE = new TextExpressionFunction();
 
     /**
      * Private ctor
@@ -57,7 +65,7 @@ final class TextExpressionFunction extends StringExpressionFunction<String> {
 
     @Override
     public String apply(final List<Object> parameters,
-                        final ExpressionFunctionContext context) {
+                        final C context) {
         this.checkParameterCount(parameters, 1);
 
         return this.string(parameters, 0, context);

--- a/src/main/java/walkingkooka/tree/expression/function/string/TrimLeftStringExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/string/TrimLeftStringExpressionFunction.java
@@ -34,6 +34,7 @@
 
 package walkingkooka.tree.expression.function.string;
 
+import walkingkooka.Cast;
 import walkingkooka.text.CharSequences;
 import walkingkooka.tree.expression.FunctionExpressionName;
 import walkingkooka.tree.expression.function.ExpressionFunctionContext;
@@ -41,11 +42,18 @@ import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 /**
  * Performs a trim left after converting the value to a {@link String}.
  */
-final class TrimLeftStringExpressionFunction extends UnaryStringExpressionFunction<String> {
+final class TrimLeftStringExpressionFunction<C extends ExpressionFunctionContext> extends UnaryStringExpressionFunction<String, C> {
+    /**
+     * Instance getter.
+     */
+    static <C extends ExpressionFunctionContext> TrimLeftStringExpressionFunction<C> instance() {
+        return Cast.to(INSTANCE);
+    }
+
     /**
      * Singleton
      */
-    static final TrimLeftStringExpressionFunction INSTANCE = new TrimLeftStringExpressionFunction();
+    private static final TrimLeftStringExpressionFunction INSTANCE = new TrimLeftStringExpressionFunction();
 
     /**
      * Private ctor

--- a/src/main/java/walkingkooka/tree/expression/function/string/TrimRightStringExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/string/TrimRightStringExpressionFunction.java
@@ -34,6 +34,7 @@
 
 package walkingkooka.tree.expression.function.string;
 
+import walkingkooka.Cast;
 import walkingkooka.text.CharSequences;
 import walkingkooka.tree.expression.FunctionExpressionName;
 import walkingkooka.tree.expression.function.ExpressionFunctionContext;
@@ -41,11 +42,18 @@ import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 /**
  * Performs a trim right after converting the value to a {@link String}.
  */
-final class TrimRightStringExpressionFunction extends UnaryStringExpressionFunction<String> {
+final class TrimRightStringExpressionFunction<C extends ExpressionFunctionContext> extends UnaryStringExpressionFunction<String, C> {
+    /**
+     * Instance getter.
+     */
+    static <C extends ExpressionFunctionContext> TrimRightStringExpressionFunction<C> instance() {
+        return Cast.to(INSTANCE);
+    }
+
     /**
      * Singleton
      */
-    static final TrimRightStringExpressionFunction INSTANCE = new TrimRightStringExpressionFunction();
+    private static final TrimRightStringExpressionFunction INSTANCE = new TrimRightStringExpressionFunction();
 
     /**
      * Private ctor

--- a/src/main/java/walkingkooka/tree/expression/function/string/UnaryStringExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/string/UnaryStringExpressionFunction.java
@@ -42,7 +42,7 @@ import java.util.List;
 /**
  * A {@link ExpressionFunction} that handles a single {@link String} parameter.
  */
-abstract class UnaryStringExpressionFunction<T> extends StringExpressionFunction<T> {
+abstract class UnaryStringExpressionFunction<T, C extends ExpressionFunctionContext> extends StringExpressionFunction<T, C> {
 
     /**
      * Package private ctor
@@ -53,7 +53,7 @@ abstract class UnaryStringExpressionFunction<T> extends StringExpressionFunction
 
     @Override
     public final T apply(final List<Object> parameters,
-                         final ExpressionFunctionContext context) {
+                         final C context) {
         this.checkParameterCount(parameters, 1);
 
         return this.applyString(this.string(parameters, 0, context), context);

--- a/src/main/java/walkingkooka/tree/expression/function/string/UnicodeExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/string/UnicodeExpressionFunction.java
@@ -16,6 +16,7 @@
  */
 package walkingkooka.tree.expression.function.string;
 
+import walkingkooka.Cast;
 import walkingkooka.tree.expression.FunctionExpressionName;
 import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
@@ -23,11 +24,18 @@ import walkingkooka.tree.expression.function.ExpressionFunctionContext;
  * Returns the unicode of the first character in the provided {@link String}
  * <a href="https://support.google.com/docs/answer/9149523?hl=en&ref_topic=3105625"></a>
  */
-final class UnicodeExpressionFunction extends UnaryStringExpressionFunction<Number> {
+final class UnicodeExpressionFunction<C extends ExpressionFunctionContext> extends UnaryStringExpressionFunction<Number, C> {
+    /**
+     * Instance getter.
+     */
+    static <C extends ExpressionFunctionContext> UnicodeExpressionFunction<C> instance() {
+        return Cast.to(INSTANCE);
+    }
+
     /**
      * Singleton
      */
-    static final UnicodeExpressionFunction INSTANCE = new UnicodeExpressionFunction();
+    private static final UnicodeExpressionFunction INSTANCE = new UnicodeExpressionFunction();
 
     /**
      * Private ctor

--- a/src/main/java/walkingkooka/tree/expression/function/string/UpperCaseStringExpressionFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/string/UpperCaseStringExpressionFunction.java
@@ -16,17 +16,25 @@
  */
 package walkingkooka.tree.expression.function.string;
 
+import walkingkooka.Cast;
 import walkingkooka.tree.expression.FunctionExpressionName;
 import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
 /**
  * Performs a lower case converting the value to a {@link String} using the current {@link java.util.Locale}.
  */
-final class UpperCaseStringExpressionFunction extends UnaryStringExpressionFunction<String> {
+final class UpperCaseStringExpressionFunction<C extends ExpressionFunctionContext> extends UnaryStringExpressionFunction<String, C> {
+    /**
+     * Instance getter.
+     */
+    static <C extends ExpressionFunctionContext> UpperCaseStringExpressionFunction<C> instance() {
+        return Cast.to(INSTANCE);
+    }
+
     /**
      * Singleton
      */
-    static final UpperCaseStringExpressionFunction INSTANCE = new UpperCaseStringExpressionFunction();
+    private static final UpperCaseStringExpressionFunction INSTANCE = new UpperCaseStringExpressionFunction();
 
     /**
      * Private ctor

--- a/src/test/java/walkingkooka/tree/expression/function/string/CharExpressionFunctionTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/string/CharExpressionFunctionTest.java
@@ -18,10 +18,12 @@
 package walkingkooka.tree.expression.function.string;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.Cast;
+import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public final class CharExpressionFunctionTest extends StringExpressionFunctionTestCase<CharExpressionFunction, Character> {
+public final class CharExpressionFunctionTest extends StringExpressionFunctionTestCase<CharExpressionFunction<ExpressionFunctionContext>, Character> {
 
     @Test
     public void testZeroParametersFails() {
@@ -74,12 +76,12 @@ public final class CharExpressionFunctionTest extends StringExpressionFunctionTe
     }
 
     @Override
-    public CharExpressionFunction createBiFunction() {
-        return CharExpressionFunction.INSTANCE;
+    public CharExpressionFunction<ExpressionFunctionContext> createBiFunction() {
+        return CharExpressionFunction.instance();
     }
 
     @Override
-    public Class<CharExpressionFunction> type() {
-        return CharExpressionFunction.class;
+    public Class<CharExpressionFunction<ExpressionFunctionContext>> type() {
+        return Cast.to(CharExpressionFunction.class);
     }
 }

--- a/src/test/java/walkingkooka/tree/expression/function/string/ConcatExpressionFunctionTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/string/ConcatExpressionFunctionTest.java
@@ -35,10 +35,12 @@
 package walkingkooka.tree.expression.function.string;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.Cast;
+import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public final class ConcatExpressionFunctionTest extends StringExpressionFunctionTestCase<ConcatExpressionFunction, String> {
+public final class ConcatExpressionFunctionTest extends StringExpressionFunctionTestCase<ConcatExpressionFunction<ExpressionFunctionContext>, String> {
 
     @Test
     public void testZeroParametersFails() {
@@ -81,12 +83,12 @@ public final class ConcatExpressionFunctionTest extends StringExpressionFunction
     }
 
     @Override
-    public ConcatExpressionFunction createBiFunction() {
-        return ConcatExpressionFunction.INSTANCE;
+    public ConcatExpressionFunction<ExpressionFunctionContext> createBiFunction() {
+        return ConcatExpressionFunction.instance();
     }
 
     @Override
-    public Class<ConcatExpressionFunction> type() {
-        return ConcatExpressionFunction.class;
+    public Class<ConcatExpressionFunction<ExpressionFunctionContext>> type() {
+        return Cast.to(ConcatExpressionFunction.class);
     }
 }

--- a/src/test/java/walkingkooka/tree/expression/function/string/ContainsExpressionFunctionTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/string/ContainsExpressionFunctionTest.java
@@ -35,8 +35,10 @@
 package walkingkooka.tree.expression.function.string;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.Cast;
+import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
-public final class ContainsExpressionFunctionTest extends StringStringBooleanExpressionFunctionTestCase<ContainsExpressionFunction> {
+public final class ContainsExpressionFunctionTest extends StringStringBooleanExpressionFunctionTestCase<ContainsExpressionFunction<ExpressionFunctionContext>> {
 
     @Test
     public void testContains() {
@@ -74,12 +76,12 @@ public final class ContainsExpressionFunctionTest extends StringStringBooleanExp
     }
 
     @Override
-    public ContainsExpressionFunction createBiFunction() {
-        return ContainsExpressionFunction.INSTANCE;
+    public ContainsExpressionFunction<ExpressionFunctionContext> createBiFunction() {
+        return ContainsExpressionFunction.instance();
     }
 
     @Override
-    public Class<ContainsExpressionFunction> type() {
-        return ContainsExpressionFunction.class;
+    public Class<ContainsExpressionFunction<ExpressionFunctionContext>> type() {
+        return Cast.to(ContainsExpressionFunction.class);
     }
 }

--- a/src/test/java/walkingkooka/tree/expression/function/string/EndsWithExpressionFunctionTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/string/EndsWithExpressionFunctionTest.java
@@ -35,8 +35,10 @@
 package walkingkooka.tree.expression.function.string;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.Cast;
+import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
-public final class EndsWithExpressionFunctionTest extends StringStringBooleanExpressionFunctionTestCase<EndsWithExpressionFunction> {
+public final class EndsWithExpressionFunctionTest extends StringStringBooleanExpressionFunctionTestCase<EndsWithExpressionFunction<ExpressionFunctionContext>> {
 
     @Test
     public void testMissing() {
@@ -79,12 +81,12 @@ public final class EndsWithExpressionFunctionTest extends StringStringBooleanExp
     }
 
     @Override
-    public EndsWithExpressionFunction createBiFunction() {
-        return EndsWithExpressionFunction.INSTANCE;
+    public EndsWithExpressionFunction<ExpressionFunctionContext> createBiFunction() {
+        return EndsWithExpressionFunction.instance();
     }
 
     @Override
-    public Class<EndsWithExpressionFunction> type() {
-        return EndsWithExpressionFunction.class;
+    public Class<EndsWithExpressionFunction<ExpressionFunctionContext>> type() {
+        return Cast.to(EndsWithExpressionFunction.class);
     }
 }

--- a/src/test/java/walkingkooka/tree/expression/function/string/LeftStringExpressionFunctionTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/string/LeftStringExpressionFunctionTest.java
@@ -35,8 +35,10 @@
 package walkingkooka.tree.expression.function.string;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.Cast;
+import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
-public final class LeftStringExpressionFunctionTest extends StringOptionalNumberStringExpressionFunctionTestCase<LeftStringExpressionFunction> {
+public final class LeftStringExpressionFunctionTest extends StringOptionalNumberStringExpressionFunctionTestCase<LeftStringExpressionFunction<ExpressionFunctionContext>> {
 
     @Test
     public void testBoolean() {
@@ -89,12 +91,12 @@ public final class LeftStringExpressionFunctionTest extends StringOptionalNumber
     }
 
     @Override
-    public LeftStringExpressionFunction createBiFunction() {
-        return LeftStringExpressionFunction.INSTANCE;
+    public LeftStringExpressionFunction<ExpressionFunctionContext> createBiFunction() {
+        return LeftStringExpressionFunction.instance();
     }
 
     @Override
-    public Class<LeftStringExpressionFunction> type() {
-        return LeftStringExpressionFunction.class;
+    public Class<LeftStringExpressionFunction<ExpressionFunctionContext>> type() {
+        return Cast.to(LeftStringExpressionFunction.class);
     }
 }

--- a/src/test/java/walkingkooka/tree/expression/function/string/LowerCaseStringExpressionFunctionTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/string/LowerCaseStringExpressionFunctionTest.java
@@ -18,16 +18,12 @@ package walkingkooka.tree.expression.function.string;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.Cast;
-import walkingkooka.Either;
 import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 import walkingkooka.tree.expression.function.ExpressionFunctionContexts;
-import walkingkooka.tree.expression.function.FakeExpressionFunctionContext;
-
-import java.util.Locale;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public final class LowerCaseStringExpressionFunctionTest extends UnaryStringExpressionFunctionTestCase<LowerCaseStringExpressionFunction, String> {
+public final class LowerCaseStringExpressionFunctionTest extends UnaryStringExpressionFunctionTestCase<LowerCaseStringExpressionFunction<ExpressionFunctionContext>, String> {
 
     @Test
     public void testBoolean() {
@@ -65,29 +61,12 @@ public final class LowerCaseStringExpressionFunctionTest extends UnaryStringExpr
     }
 
     @Override
-    public LowerCaseStringExpressionFunction createBiFunction() {
-        return LowerCaseStringExpressionFunction.INSTANCE;
+    public LowerCaseStringExpressionFunction<ExpressionFunctionContext> createBiFunction() {
+        return LowerCaseStringExpressionFunction.instance();
     }
 
     @Override
-    public Class<LowerCaseStringExpressionFunction> type() {
-        return LowerCaseStringExpressionFunction.class;
-    }
-
-    @Override
-    public ExpressionFunctionContext createContext() {
-        return new FakeExpressionFunctionContext() {
-
-            @Override
-            public <T> Either<T, String> convert(final Object value,
-                                                 final Class<T> target) {
-                return Cast.to(Either.left(value.toString()));
-            }
-
-            @Override
-            public Locale locale() {
-                return Locale.ENGLISH;
-            }
-        };
+    public Class<LowerCaseStringExpressionFunction<ExpressionFunctionContext>> type() {
+        return Cast.to(LowerCaseStringExpressionFunction.class);
     }
 }

--- a/src/test/java/walkingkooka/tree/expression/function/string/MidStringExpressionFunctionTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/string/MidStringExpressionFunctionTest.java
@@ -18,10 +18,12 @@
 package walkingkooka.tree.expression.function.string;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.Cast;
+import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public final class MidStringExpressionFunctionTest extends StringExpressionFunctionTestCase<MidStringExpressionFunction, String> {
+public final class MidStringExpressionFunctionTest extends StringExpressionFunctionTestCase<MidStringExpressionFunction<ExpressionFunctionContext>, String> {
 
     @Test
     public void testZeroParametersFails() {
@@ -109,12 +111,12 @@ public final class MidStringExpressionFunctionTest extends StringExpressionFunct
     }
 
     @Override
-    public MidStringExpressionFunction createBiFunction() {
-        return MidStringExpressionFunction.INSTANCE;
+    public MidStringExpressionFunction<ExpressionFunctionContext> createBiFunction() {
+        return MidStringExpressionFunction.instance();
     }
 
     @Override
-    public Class<MidStringExpressionFunction> type() {
-        return MidStringExpressionFunction.class;
+    public Class<MidStringExpressionFunction<ExpressionFunctionContext>> type() {
+        return Cast.to(MidStringExpressionFunction.class);
     }
 }

--- a/src/test/java/walkingkooka/tree/expression/function/string/NormalizeSpaceExpressionFunctionTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/string/NormalizeSpaceExpressionFunctionTest.java
@@ -35,8 +35,10 @@
 package walkingkooka.tree.expression.function.string;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.Cast;
+import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
-public final class NormalizeSpaceExpressionFunctionTest extends UnaryStringExpressionFunctionTestCase<NormalizeSpaceExpressionFunction, String> {
+public final class NormalizeSpaceExpressionFunctionTest extends UnaryStringExpressionFunctionTestCase<NormalizeSpaceExpressionFunction<ExpressionFunctionContext>, String> {
 
     @Test
     public void testUnnecessary() {
@@ -118,12 +120,12 @@ public final class NormalizeSpaceExpressionFunctionTest extends UnaryStringExpre
     }
 
     @Override
-    public NormalizeSpaceExpressionFunction createBiFunction() {
-        return NormalizeSpaceExpressionFunction.INSTANCE;
+    public NormalizeSpaceExpressionFunction<ExpressionFunctionContext> createBiFunction() {
+        return NormalizeSpaceExpressionFunction.instance();
     }
 
     @Override
-    public Class<NormalizeSpaceExpressionFunction> type() {
-        return NormalizeSpaceExpressionFunction.class;
+    public Class<NormalizeSpaceExpressionFunction<ExpressionFunctionContext>> type() {
+        return Cast.to(NormalizeSpaceExpressionFunction.class);
     }
 }

--- a/src/test/java/walkingkooka/tree/expression/function/string/RightStringExpressionFunctionTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/string/RightStringExpressionFunctionTest.java
@@ -35,8 +35,10 @@
 package walkingkooka.tree.expression.function.string;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.Cast;
+import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
-public final class RightStringExpressionFunctionTest extends StringOptionalNumberStringExpressionFunctionTestCase<RightStringExpressionFunction> {
+public final class RightStringExpressionFunctionTest extends StringOptionalNumberStringExpressionFunctionTestCase<RightStringExpressionFunction<ExpressionFunctionContext>> {
 
     @Test
     public void testBoolean() {
@@ -94,12 +96,12 @@ public final class RightStringExpressionFunctionTest extends StringOptionalNumbe
     }
 
     @Override
-    public RightStringExpressionFunction createBiFunction() {
-        return RightStringExpressionFunction.INSTANCE;
+    public RightStringExpressionFunction<ExpressionFunctionContext> createBiFunction() {
+        return RightStringExpressionFunction.instance();
     }
 
     @Override
-    public Class<RightStringExpressionFunction> type() {
-        return RightStringExpressionFunction.class;
+    public Class<RightStringExpressionFunction<ExpressionFunctionContext>> type() {
+        return Cast.to(RightStringExpressionFunction.class);
     }
 }

--- a/src/test/java/walkingkooka/tree/expression/function/string/StartsWithExpressionFunctionTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/string/StartsWithExpressionFunctionTest.java
@@ -35,8 +35,10 @@
 package walkingkooka.tree.expression.function.string;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.Cast;
+import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
-public final class StartsWithExpressionFunctionTest extends StringStringBooleanExpressionFunctionTestCase<StartsWithExpressionFunction> {
+public final class StartsWithExpressionFunctionTest extends StringStringBooleanExpressionFunctionTestCase<StartsWithExpressionFunction<ExpressionFunctionContext>> {
 
     @Test
     public void testMissing() {
@@ -79,12 +81,12 @@ public final class StartsWithExpressionFunctionTest extends StringStringBooleanE
     }
 
     @Override
-    public StartsWithExpressionFunction createBiFunction() {
-        return StartsWithExpressionFunction.INSTANCE;
+    public StartsWithExpressionFunction<ExpressionFunctionContext> createBiFunction() {
+        return StartsWithExpressionFunction.instance();
     }
 
     @Override
-    public Class<StartsWithExpressionFunction> type() {
-        return StartsWithExpressionFunction.class;
+    public Class<StartsWithExpressionFunction<ExpressionFunctionContext>> type() {
+        return Cast.to(StartsWithExpressionFunction.class);
     }
 }

--- a/src/test/java/walkingkooka/tree/expression/function/string/StringExpressionFunctionTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/string/StringExpressionFunctionTest.java
@@ -38,10 +38,10 @@ import walkingkooka.Cast;
 import walkingkooka.reflect.ClassTesting2;
 import walkingkooka.reflect.JavaVisibility;
 
-public final class StringExpressionFunctionTest implements ClassTesting2<StringExpressionFunction<?>> {
+public final class StringExpressionFunctionTest implements ClassTesting2<StringExpressionFunction<?, ?>> {
 
     @Override
-    public Class<StringExpressionFunction<?>> type() {
+    public Class<StringExpressionFunction<?, ?>> type() {
         return Cast.to(StringExpressionFunction.class);
     }
 

--- a/src/test/java/walkingkooka/tree/expression/function/string/StringExpressionFunctionTestCase.java
+++ b/src/test/java/walkingkooka/tree/expression/function/string/StringExpressionFunctionTestCase.java
@@ -16,16 +16,62 @@
  */
 package walkingkooka.tree.expression.function.string;
 
+import walkingkooka.Cast;
+import walkingkooka.Either;
 import walkingkooka.reflect.ClassTesting2;
 import walkingkooka.reflect.JavaVisibility;
 import walkingkooka.tree.expression.function.ExpressionFunction;
+import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 import walkingkooka.tree.expression.function.ExpressionFunctionTesting;
+import walkingkooka.tree.expression.function.FakeExpressionFunctionContext;
 
-public abstract class StringExpressionFunctionTestCase<F extends ExpressionFunction<T>, T> implements ExpressionFunctionTesting<F, T>,
+import java.util.List;
+import java.util.Locale;
+
+public abstract class StringExpressionFunctionTestCase<F extends ExpressionFunction<T, ExpressionFunctionContext>, T> implements ExpressionFunctionTesting<F, T, ExpressionFunctionContext>,
         ClassTesting2<F> {
 
     StringExpressionFunctionTestCase() {
         super();
+    }
+
+    final void apply2(final Object... parameters) {
+        this.createBiFunction().apply(parameters(parameters), this.createContext());
+    }
+
+    final void applyAndCheck2(final List<Object> parameters,
+                              final T result) {
+        this.applyAndCheck2(this.createBiFunction(), parameters, result);
+    }
+
+    final void applyAndCheck2(final ExpressionFunction<T, ExpressionFunctionContext> function,
+                              final List<Object> parameters,
+                              final T result) {
+        this.applyAndCheck2(function, parameters, this.createContext(), result);
+    }
+
+    @Override
+    public final ExpressionFunctionContext createContext() {
+        return new FakeExpressionFunctionContext() {
+
+            @Override
+            public <T> Either<T, String> convert(final Object value,
+                                                 final Class<T> target) {
+                if (target.isInstance(value)) {
+                    return Cast.to(Either.left(target.cast(value)));
+                }
+                if (Integer.class == target) {
+                    return Cast.to(Either.left(Integer.parseInt(value.toString())));
+                }
+
+                return Cast.to(Either.left(value.toString()));
+            }
+
+            @Override
+            public Locale locale() {
+                return Locale.forLanguageTag("DE");
+            }
+        };
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/expression/function/string/StringLengthExpressionFunctionTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/string/StringLengthExpressionFunctionTest.java
@@ -35,8 +35,10 @@
 package walkingkooka.tree.expression.function.string;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.Cast;
+import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
-public final class StringLengthExpressionFunctionTest extends UnaryStringExpressionFunctionTestCase<StringLengthExpressionFunction, Number> {
+public final class StringLengthExpressionFunctionTest extends UnaryStringExpressionFunctionTestCase<StringLengthExpressionFunction<ExpressionFunctionContext>, Number> {
 
     @Test
     public void testEmptyString() {
@@ -64,12 +66,12 @@ public final class StringLengthExpressionFunctionTest extends UnaryStringExpress
     }
 
     @Override
-    public StringLengthExpressionFunction createBiFunction() {
-        return StringLengthExpressionFunction.INSTANCE;
+    public StringLengthExpressionFunction<ExpressionFunctionContext> createBiFunction() {
+        return StringLengthExpressionFunction.instance();
     }
 
     @Override
-    public Class<StringLengthExpressionFunction> type() {
-        return StringLengthExpressionFunction.class;
+    public Class<StringLengthExpressionFunction<ExpressionFunctionContext>> type() {
+        return Cast.to(StringLengthExpressionFunction.class);
     }
 }

--- a/src/test/java/walkingkooka/tree/expression/function/string/StringOptionalNumberStringExpressionFunctionTestCase.java
+++ b/src/test/java/walkingkooka/tree/expression/function/string/StringOptionalNumberStringExpressionFunctionTestCase.java
@@ -17,10 +17,11 @@
 package walkingkooka.tree.expression.function.string;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public abstract class StringOptionalNumberStringExpressionFunctionTestCase<F extends StringOptionalNumberStringExpressionFunction> extends StringExpressionFunctionTestCase<F, String> {
+public abstract class StringOptionalNumberStringExpressionFunctionTestCase<F extends StringOptionalNumberStringExpressionFunction<ExpressionFunctionContext>> extends StringExpressionFunctionTestCase<F, String> {
 
     StringOptionalNumberStringExpressionFunctionTestCase() {
         super();

--- a/src/test/java/walkingkooka/tree/expression/function/string/StringStringBooleanExpressionFunctionTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/string/StringStringBooleanExpressionFunctionTest.java
@@ -17,14 +17,16 @@
 
 package walkingkooka.tree.expression.function.string;
 
+import walkingkooka.Cast;
 import walkingkooka.reflect.ClassTesting;
 import walkingkooka.reflect.JavaVisibility;
+import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
-public final class StringStringBooleanExpressionFunctionTest implements ClassTesting<StringStringBooleanExpressionFunction> {
+public final class StringStringBooleanExpressionFunctionTest implements ClassTesting<StringStringBooleanExpressionFunction<ExpressionFunctionContext>> {
 
     @Override
-    public Class<StringStringBooleanExpressionFunction> type() {
-        return StringStringBooleanExpressionFunction.class;
+    public Class<StringStringBooleanExpressionFunction<ExpressionFunctionContext>> type() {
+        return Cast.to(StringStringBooleanExpressionFunction.class);
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/expression/function/string/StringStringBooleanExpressionFunctionTestCase.java
+++ b/src/test/java/walkingkooka/tree/expression/function/string/StringStringBooleanExpressionFunctionTestCase.java
@@ -17,10 +17,11 @@
 package walkingkooka.tree.expression.function.string;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public abstract class StringStringBooleanExpressionFunctionTestCase<F extends StringStringBooleanExpressionFunction> extends StringExpressionFunctionTestCase<F, Boolean> {
+public abstract class StringStringBooleanExpressionFunctionTestCase<F extends StringStringBooleanExpressionFunction<ExpressionFunctionContext>> extends StringExpressionFunctionTestCase<F, Boolean> {
 
     StringStringBooleanExpressionFunctionTestCase() {
         super();

--- a/src/test/java/walkingkooka/tree/expression/function/string/StringStringStringExpressionFunctionTestCase.java
+++ b/src/test/java/walkingkooka/tree/expression/function/string/StringStringStringExpressionFunctionTestCase.java
@@ -17,10 +17,11 @@
 package walkingkooka.tree.expression.function.string;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public abstract class StringStringStringExpressionFunctionTestCase<F extends StringStringStringExpressionFunction> extends StringExpressionFunctionTestCase<F, String> {
+public abstract class StringStringStringExpressionFunctionTestCase<F extends StringStringStringExpressionFunction<ExpressionFunctionContext>> extends StringExpressionFunctionTestCase<F, String> {
 
     StringStringStringExpressionFunctionTestCase() {
         super();

--- a/src/test/java/walkingkooka/tree/expression/function/string/SubstringAfterExpressionFunctionTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/string/SubstringAfterExpressionFunctionTest.java
@@ -35,8 +35,10 @@
 package walkingkooka.tree.expression.function.string;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.Cast;
+import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
-public final class SubstringAfterExpressionFunctionTest extends StringStringStringExpressionFunctionTestCase<SubstringAfterExpressionFunction> {
+public final class SubstringAfterExpressionFunctionTest extends StringStringStringExpressionFunctionTestCase<SubstringAfterExpressionFunction<ExpressionFunctionContext>> {
 
     @Test
     public void testMissing() {
@@ -69,12 +71,12 @@ public final class SubstringAfterExpressionFunctionTest extends StringStringStri
     }
 
     @Override
-    public SubstringAfterExpressionFunction createBiFunction() {
-        return SubstringAfterExpressionFunction.INSTANCE;
+    public SubstringAfterExpressionFunction<ExpressionFunctionContext> createBiFunction() {
+        return SubstringAfterExpressionFunction.instance();
     }
 
     @Override
-    public Class<SubstringAfterExpressionFunction> type() {
-        return SubstringAfterExpressionFunction.class;
+    public Class<SubstringAfterExpressionFunction<ExpressionFunctionContext>> type() {
+        return Cast.to(SubstringAfterExpressionFunction.class);
     }
 }

--- a/src/test/java/walkingkooka/tree/expression/function/string/SubstringBeforeExpressionFunctionTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/string/SubstringBeforeExpressionFunctionTest.java
@@ -35,8 +35,10 @@
 package walkingkooka.tree.expression.function.string;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.Cast;
+import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
-public final class SubstringBeforeExpressionFunctionTest extends StringStringStringExpressionFunctionTestCase<SubstringBeforeExpressionFunction> {
+public final class SubstringBeforeExpressionFunctionTest extends StringStringStringExpressionFunctionTestCase<SubstringBeforeExpressionFunction<ExpressionFunctionContext>> {
 
     @Test
     public void testMissing() {
@@ -74,12 +76,12 @@ public final class SubstringBeforeExpressionFunctionTest extends StringStringStr
     }
 
     @Override
-    public SubstringBeforeExpressionFunction createBiFunction() {
-        return SubstringBeforeExpressionFunction.INSTANCE;
+    public SubstringBeforeExpressionFunction<ExpressionFunctionContext> createBiFunction() {
+        return SubstringBeforeExpressionFunction.instance();
     }
 
     @Override
-    public Class<SubstringBeforeExpressionFunction> type() {
-        return SubstringBeforeExpressionFunction.class;
+    public Class<SubstringBeforeExpressionFunction<ExpressionFunctionContext>> type() {
+        return Cast.to(SubstringBeforeExpressionFunction.class);
     }
 }

--- a/src/test/java/walkingkooka/tree/expression/function/string/SubstringExpressionFunctionTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/string/SubstringExpressionFunctionTest.java
@@ -35,11 +35,13 @@
 package walkingkooka.tree.expression.function.string;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.Cast;
+import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 import walkingkooka.tree.select.NodeSelector;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public final class SubstringExpressionFunctionTest extends StringExpressionFunctionTestCase<SubstringExpressionFunction, String> {
+public final class SubstringExpressionFunctionTest extends StringExpressionFunctionTestCase<SubstringExpressionFunction<ExpressionFunctionContext>, String> {
 
     @Test
     public void testZeroParametersFails() {
@@ -107,12 +109,12 @@ public final class SubstringExpressionFunctionTest extends StringExpressionFunct
     }
 
     @Override
-    public SubstringExpressionFunction createBiFunction() {
+    public SubstringExpressionFunction<ExpressionFunctionContext> createBiFunction() {
         return SubstringExpressionFunction.with(NodeSelector.INDEX_BIAS);
     }
 
     @Override
-    public Class<SubstringExpressionFunction> type() {
-        return SubstringExpressionFunction.class;
+    public Class<SubstringExpressionFunction<ExpressionFunctionContext>> type() {
+        return Cast.to(SubstringExpressionFunction.class);
     }
 }

--- a/src/test/java/walkingkooka/tree/expression/function/string/TextExpressionFunctionTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/string/TextExpressionFunctionTest.java
@@ -35,10 +35,12 @@
 package walkingkooka.tree.expression.function.string;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.Cast;
+import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public final class TextExpressionFunctionTest extends StringExpressionFunctionTestCase<TextExpressionFunction, String> {
+public final class TextExpressionFunctionTest extends StringExpressionFunctionTestCase<TextExpressionFunction<ExpressionFunctionContext>, String> {
 
     @Test
     public void testZeroParametersFails() {
@@ -71,12 +73,12 @@ public final class TextExpressionFunctionTest extends StringExpressionFunctionTe
     }
 
     @Override
-    public TextExpressionFunction createBiFunction() {
-        return TextExpressionFunction.INSTANCE;
+    public TextExpressionFunction<ExpressionFunctionContext> createBiFunction() {
+        return TextExpressionFunction.instance();
     }
 
     @Override
-    public Class<TextExpressionFunction> type() {
-        return TextExpressionFunction.class;
+    public Class<TextExpressionFunction<ExpressionFunctionContext>> type() {
+        return Cast.to(TextExpressionFunction.class);
     }
 }

--- a/src/test/java/walkingkooka/tree/expression/function/string/TrimLeftStringExpressionFunctionTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/string/TrimLeftStringExpressionFunctionTest.java
@@ -35,8 +35,10 @@
 package walkingkooka.tree.expression.function.string;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.Cast;
+import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
-public final class TrimLeftStringExpressionFunctionTest extends UnaryStringExpressionFunctionTestCase<TrimLeftStringExpressionFunction, String> {
+public final class TrimLeftStringExpressionFunctionTest extends UnaryStringExpressionFunctionTestCase<TrimLeftStringExpressionFunction<ExpressionFunctionContext>, String> {
 
     @Test
     public void testBoolean() {
@@ -69,12 +71,12 @@ public final class TrimLeftStringExpressionFunctionTest extends UnaryStringExpre
     }
 
     @Override
-    public TrimLeftStringExpressionFunction createBiFunction() {
-        return TrimLeftStringExpressionFunction.INSTANCE;
+    public TrimLeftStringExpressionFunction<ExpressionFunctionContext> createBiFunction() {
+        return TrimLeftStringExpressionFunction.instance();
     }
 
     @Override
-    public Class<TrimLeftStringExpressionFunction> type() {
-        return TrimLeftStringExpressionFunction.class;
+    public Class<TrimLeftStringExpressionFunction<ExpressionFunctionContext>> type() {
+        return Cast.to(TrimLeftStringExpressionFunction.class);
     }
 }

--- a/src/test/java/walkingkooka/tree/expression/function/string/TrimRightStringExpressionFunctionTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/string/TrimRightStringExpressionFunctionTest.java
@@ -35,8 +35,10 @@
 package walkingkooka.tree.expression.function.string;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.Cast;
+import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
-public final class TrimRightStringExpressionFunctionTest extends UnaryStringExpressionFunctionTestCase<TrimRightStringExpressionFunction, String> {
+public final class TrimRightStringExpressionFunctionTest extends UnaryStringExpressionFunctionTestCase<TrimRightStringExpressionFunction<ExpressionFunctionContext>, String> {
 
     @Test
     public void testBoolean() {
@@ -74,12 +76,12 @@ public final class TrimRightStringExpressionFunctionTest extends UnaryStringExpr
     }
 
     @Override
-    public TrimRightStringExpressionFunction createBiFunction() {
-        return TrimRightStringExpressionFunction.INSTANCE;
+    public TrimRightStringExpressionFunction<ExpressionFunctionContext> createBiFunction() {
+        return TrimRightStringExpressionFunction.instance();
     }
 
     @Override
-    public Class<TrimRightStringExpressionFunction> type() {
-        return TrimRightStringExpressionFunction.class;
+    public Class<TrimRightStringExpressionFunction<ExpressionFunctionContext>> type() {
+        return Cast.to(TrimRightStringExpressionFunction.class);
     }
 }

--- a/src/test/java/walkingkooka/tree/expression/function/string/UnaryStringExpressionFunctionTestCase.java
+++ b/src/test/java/walkingkooka/tree/expression/function/string/UnaryStringExpressionFunctionTestCase.java
@@ -17,10 +17,11 @@
 package walkingkooka.tree.expression.function.string;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public abstract class UnaryStringExpressionFunctionTestCase<F extends UnaryStringExpressionFunction<T>, T> extends StringExpressionFunctionTestCase<F, T> {
+public abstract class UnaryStringExpressionFunctionTestCase<F extends UnaryStringExpressionFunction<T, ExpressionFunctionContext>, T> extends StringExpressionFunctionTestCase<F, T> {
 
     UnaryStringExpressionFunctionTestCase() {
         super();

--- a/src/test/java/walkingkooka/tree/expression/function/string/UnicodeExpressionFunctionTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/string/UnicodeExpressionFunctionTest.java
@@ -17,10 +17,12 @@
 package walkingkooka.tree.expression.function.string;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.Cast;
+import walkingkooka.tree.expression.function.ExpressionFunctionContext;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public final class UnicodeExpressionFunctionTest extends UnaryStringExpressionFunctionTestCase<UnicodeExpressionFunction, Number> {
+public final class UnicodeExpressionFunctionTest extends UnaryStringExpressionFunctionTestCase<UnicodeExpressionFunction<ExpressionFunctionContext>, Number> {
 
     @Test
     public void testEmptyString() {
@@ -58,12 +60,12 @@ public final class UnicodeExpressionFunctionTest extends UnaryStringExpressionFu
     }
 
     @Override
-    public UnicodeExpressionFunction createBiFunction() {
-        return UnicodeExpressionFunction.INSTANCE;
+    public UnicodeExpressionFunction<ExpressionFunctionContext> createBiFunction() {
+        return UnicodeExpressionFunction.instance();
     }
 
     @Override
-    public Class<UnicodeExpressionFunction> type() {
-        return UnicodeExpressionFunction.class;
+    public Class<UnicodeExpressionFunction<ExpressionFunctionContext>> type() {
+        return Cast.to(UnicodeExpressionFunction.class);
     }
 }

--- a/src/test/java/walkingkooka/tree/expression/function/string/UpperCaseStringExpressionFunctionTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/string/UpperCaseStringExpressionFunctionTest.java
@@ -18,13 +18,9 @@ package walkingkooka.tree.expression.function.string;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.Cast;
-import walkingkooka.Either;
 import walkingkooka.tree.expression.function.ExpressionFunctionContext;
-import walkingkooka.tree.expression.function.FakeExpressionFunctionContext;
 
-import java.util.Locale;
-
-public final class UpperCaseStringExpressionFunctionTest extends UnaryStringExpressionFunctionTestCase<UpperCaseStringExpressionFunction, String> {
+public final class UpperCaseStringExpressionFunctionTest extends UnaryStringExpressionFunctionTestCase<UpperCaseStringExpressionFunction<ExpressionFunctionContext>, String> {
 
     @Test
     public void testBoolean() {
@@ -57,29 +53,12 @@ public final class UpperCaseStringExpressionFunctionTest extends UnaryStringExpr
     }
 
     @Override
-    public UpperCaseStringExpressionFunction createBiFunction() {
-        return UpperCaseStringExpressionFunction.INSTANCE;
+    public UpperCaseStringExpressionFunction<ExpressionFunctionContext> createBiFunction() {
+        return UpperCaseStringExpressionFunction.instance();
     }
 
     @Override
-    public Class<UpperCaseStringExpressionFunction> type() {
-        return UpperCaseStringExpressionFunction.class;
-    }
-
-    @Override
-    public ExpressionFunctionContext createContext() {
-        return new FakeExpressionFunctionContext() {
-
-            @Override
-            public <T> Either<T, String> convert(final Object value,
-                                                 final Class<T> target) {
-                return Cast.to(Either.left(value.toString()));
-            }
-
-            @Override
-            public Locale locale() {
-                return Locale.forLanguageTag("DE");
-            }
-        };
+    public Class<UpperCaseStringExpressionFunction<ExpressionFunctionContext>> type() {
+        return Cast.to(UpperCaseStringExpressionFunction.class);
     }
 }


### PR DESCRIPTION
- https://github.com/mP1/walkingkooka-tree/pull/204
- ExpressionFunction ExpressionFunctionContext type parameter

- NodeSelectorContext removed convert, function methods.
- BasicNodeSelectorContext removed Converter, ConverterContext, Function functions replaced with Function<NodeSelectorContext, ExpressionEvaluationContext>
- Introduced NodeSelectorExpressionFunctionContext
- Added NodeExpressionFunction

- https://github.com/mP1/walkingkooka-tree/issues/201
- NodeExpressionFunction returns current Node by querying NodeExpressionFunctionContext.node()

- https://github.com/mP1/walkingkooka-tree/issues/200
- NodeSelectorExpressionFunctionContext extends ExpressionFunctionContext

- https://github.com/mP1/walkingkooka-tree/issues/193
- NodeSelectorContext need a better way to share current Node with expressions