### PR TITLE
BooleanExpressionFunctionContainsStartsEnds 2nd parameter kinds match…

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/function/string/BooleanExpressionFunctionContainsStartsEnds.java
+++ b/src/main/java/walkingkooka/tree/expression/function/string/BooleanExpressionFunctionContainsStartsEnds.java
@@ -134,7 +134,8 @@ final class BooleanExpressionFunctionContainsStartsEnds<C extends ExpressionEval
                                                         final BiFunction<String, String, Boolean> predicate) {
         super(name);
         this.secondParameter = ExpressionFunctionParameterName.with(secondParameterName)
-                .required(String.class);
+                .required(String.class)
+                .setKinds(TEXT.kinds());
         this.parameters = ExpressionFunctionParameter.list(
                 TEXT,
                 this.secondParameter


### PR DESCRIPTION
… first

- Previously 2nd parameter values were not converted/evaluated to string